### PR TITLE
Godisreal patch 2 manual

### DIFF
--- a/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
+++ b/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
@@ -625,7 +625,7 @@ boundary of a agent crowd).  If ``straight towards door'' would mean
 turning towards a high left (or right) density then the flow field is
 used instead.
 
-If \Timtt{EVAC\_FDS6=.TRUE.} is given then the user should not give
+When writing an input file for FDS6, the user should not give
 any additional evacuation flow fields nor vents.  There are two basic
 levels in the evacuation meshes.  One is the main evacuation mesh
 location at the $z$-level given by the \Timtt{XB} on the mesh line.

--- a/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
+++ b/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
@@ -521,7 +521,7 @@ much from the version 2.5.0.  Just some bugs are corrected.
 \noindent The version 2.5.0 of the evacuation module does not differ
 much from the version 2.4.1.  Just some bugs are corrected and some
 old user input are disabled.  This version does not support anymore
-FDS 5 style evacuation inputs.  Now just the main evacuation meshes
+FDS 5 style evacuation inputs, and \Timtt{EVAC\_FDS6=.FALSE.} is not supported anymore.  Now just the main evacuation meshes
 are defined by the user and no ``outflow'' vents are defined.  The
 \Timtt{STRS} namelist for the staircases is more automatic, it defines
 its own mesh(es) automatically.


### PR DESCRIPTION
I tested EVAC_FDS6=.FALSE., and it is not usable.  
So vents are not needed in the evacuation input file.  Maybe the manual is to be updated.  