### PR TITLE
Add hazard force

### DIFF
--- a/Source/type.f90
+++ b/Source/type.f90
@@ -702,6 +702,7 @@ TYPE HUMAN_TYPE
    REAL(EB) :: T_FallenDown=0._EB, F_FallDown=0._EB, Angle_FallenDown=0._EB, SizeFac_FallenDown=0._EB, T_CheckFallDown=0._EB
    INTEGER  :: IOR=-1, ILABEL=0, COLOR_INDEX=0, INODE=0, IMESH=-1, IPC=0, IEL=0, I_FFIELD=0, I_Target2=0, ID_CB=-1
    INTEGER  :: GROUP_ID=0, DETECT1=0, GROUP_SIZE=0, I_Target=0, I_DoorAlgo=0, I_Door_Mode=0, STRS_Direction = 1
+   REAL(EB) :: FX_Hazard=0._EB, FY_Hazard=0._EB
    INTEGER  :: STR_SUB_INDX, SKIP_WALL_FORCE_IOR
    LOGICAL  :: SHOW=.TRUE., NewRnd=.TRUE., CROWBAR_READ_IN=.FALSE., CROWBAR_UPDATE_V0=.FALSE.
    LOGICAL  :: SeeDoorXB1=.FALSE., SeeDoorXB2=.FALSE., SeeDoorXYZ1=.FALSE., SeeDoorXYZ2=.FALSE.


### PR DESCRIPTION
Hazard force is used to characterize heat and smoke effect (TMP_G and SOOT_DENS) on agent movement.  This is a force-based approach to model smoke-and-agent interaction (smoke commonly spreads with heat in fire simulation).  
Current value used in my recent test:       
HEAT_GRAD_FAC = 0.2_EB 
SMOKE_BLK_FAC = 0.6_EB
More tests are needed.  Comments are welcome.  